### PR TITLE
DEV-13 LodqaClient.post_queryで指定するcallback_urlを #8 で追加したパスに変更

### DIFF
--- a/lib/register_query.rb
+++ b/lib/register_query.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-require "#{Rails.root}/lib/lodqa_client.rb"
-
 # LODQA BSにクエリーを登録するスクリプトを追加する
 LodqaClient.post_query 'Which genes are associated with Endothelin receptor type B?'


### PR DESCRIPTION
Closed #13

[対応内容]
LodqaClient.post_queryで指定するcallback_urlを #8 で追加したパスに変更

[確認内容]
・lib/lodqa_client.rbファイルが修正されていること
　SERVER_URL・CALLBACK_URLの指定値変更修正
・lib/register_query.rbファイルが修正されていること
　require（lib/lodqa_client.rbファイル）追加

[結果確認]
_lodqa_email_agent起動_
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

_lodqa_bs起動_
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

_実行（rails runner lib/register_query.rb）_
![image](https://user-images.githubusercontent.com/39178089/43759425-2a439050-9a5a-11e8-9f57-aa472af3faeb.png)

_実行結果（lodqa_email_agent のログにLODQA BSの実行結果が表示されること）_
start_search
```
Started POST "/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress" for 172.17.0.1 at 2018-08-07 06:42:12 +0000
Processing by ProgressesController#create as */*
  Parameters: {"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "message"=>"Searching the query c28c2cf9-d578-46c8-8d50-a42c88b1aa17 have been starting.", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "message"=>"Searching the query c28c2cf9-d578-46c8-8d50-a42c88b1aa17 have been starting."}}
<ActionController::Parameters {"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "message"=>"Searching the query c28c2cf9-d578-46c8-8d50-a42c88b1aa17 have been starting.", "controller"=>"progresses", "action"=>"create", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "message"=>"Searching the query c28c2cf9-d578-46c8-8d50-a42c88b1aa17 have been starting."}} permitted: false>
Completed 204 No Content in 1ms
```

finish_search
```
Started POST "/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress" for 172.17.0.1 at 2018-08-07 06:43:11 +0000
Processing by ProgressesController#create as */*
  Parameters: {"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "finish_at"=>"2018-08-07T06:43:11.236+00:00", "elapsed_time"=>59.1657448, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}], "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "finish_at"=>"2018-08-07T06:43:11.236+00:00", "elapsed_time"=>59.1657448, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}]}}
<ActionController::Parameters {"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "finish_at"=>"2018-08-07T06:43:11.236+00:00", "elapsed_time"=>59.1657448, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}], "controller"=>"progresses", "action"=>"create", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-07T06:42:12.070+00:00", "finish_at"=>"2018-08-07T06:43:11.236+00:00", "elapsed_time"=>59.1657448, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}]}} permitted: false>
Completed 204 No Content in 1ms
```
