### PR TITLE
DEV-16 urlに指定するホスト名を環境変数から取得

### DIFF
--- a/app/models/lodqa_client.rb
+++ b/app/models/lodqa_client.rb
@@ -3,8 +3,8 @@
 # LODQA BSにHTTPリクエストを送る
 module LodqaClient
   class << self
-    SERVER_URL = 'http://' + ENV['HOST_LODQA_BS'] + '/queries'
-    CALLBACK_URL = 'http://' + ENV['HOST'] + '/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress'
+    SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/queries"
+    CALLBACK_URL = "http://#{ENV['HOST']}/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress"
 
     def post_query(question)
       post_params = { query: question,


### PR DESCRIPTION
Closed #16

[対応内容]
urlに指定するホスト名を環境変数から取得

[確認内容]
・lib/lodqa_client.rbファイルが修正されていること
　SERVER_URL・CALLBACK_URLのホスト名とポート番号を環境変数から設定

[結果確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

lodqa_bs起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

実行
（env HOST_LODQA_BS=localhost:81 HOST=host.docker.internal:80 rails runner lib/register_query.rb）
![image](https://user-images.githubusercontent.com/39178089/43817694-bdd369e2-9b15-11e8-9f50-4852a3a12416.png)

_実行結果（lodqa_email_agent のログにLODQA BSの実行結果が表示されること）_
start_search
```
Started POST "/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress" for 172.17.0.1 at 2018-08-08 05:05:29 +0000
Processing by ProgressesController#create as */*
  Parameters: {"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "message"=>"Searching the query 6fb7b09c-cc2f-46c7-8920-81a156479483 have been starting.", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "message"=>"Searching the query 6fb7b09c-cc2f-46c7-8920-81a156479483 have been starting."}}
<ActionController::Parameters {"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "message"=>"Searching the query 6fb7b09c-cc2f-46c7-8920-81a156479483 have been starting.", "controller"=>"progresses", "action"=>"create", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "message"=>"Searching the query 6fb7b09c-cc2f-46c7-8920-81a156479483 have been starting."}} permitted: false>
Completed 204 No Content in 0ms
```

finish_search
```
Started POST "/queries/310d4eab-d454-4087-954e-a4b1638c5af2/progress" for 172.17.0.1 at 2018-08-08 05:06:31 +0000
Processing by ProgressesController#create as */*
  Parameters: {"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "finish_at"=>"2018-08-08T05:06:30.263+00:00", "elapsed_time"=>61.4579841, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}], "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "finish_at"=>"2018-08-08T05:06:30.263+00:00", "elapsed_time"=>61.4579841, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}]}}
<ActionController::Parameters {"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "finish_at"=>"2018-08-08T05:06:30.263+00:00", "elapsed_time"=>61.4579841, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}], "controller"=>"progresses", "action"=>"create", "query_id"=>"310d4eab-d454-4087-954e-a4b1638c5af2", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-08T05:05:28.805+00:00", "finish_at"=>"2018-08-08T05:06:30.263+00:00", "elapsed_time"=>61.4579841, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCDS", "label"=>"ABCDS"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/BSEP", "label"=>"BSEP"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}]}} permitted: false>
Completed 204 No Content in 1ms
```