### PR TITLE
DEV-31 メールの本文からクエリを取得する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,9 +13,6 @@ Metrics/AbcSize:
 LineLength:
   Max: 130 # 1行あたりの文字数チェック
 
-Semicolon:
-  AllowAsExpressionSeparator: true
-
 AllCops:
   Exclude:
     - config.ru

--- a/app/labor/mail_receiver.rb
+++ b/app/labor/mail_receiver.rb
@@ -17,30 +17,9 @@ module MailReceiver
     imap.select('INBOX')
     # 全てのメールを取得
     ids = imap.search(['ALL'])
-
-    questions = query_value(imap, ids)
-    questions.compact! if questions.present?
-  end
-
-  def self.query_value(imap, ids)
     imap.fetch(ids, 'RFC822').map do |m|
       mail = Mail.new(m.attr['RFC822'])
-      body = nil
-      if mail.multipart?
-        # plantextなメールかチェック
-        if mail.text_part
-          body = mail.text_part.decoded
-        # htmlなメールかチェック
-        elsif mail.html_part
-          body = mail.html_part.decoded
-        end
-      else
-        body = mail.body
-      end
-      if body.include?('query')
-        query_value = body.gsub(/[{\"}]/, '')
-        query_value.split(', ').map { |h| (h1, h2) = h.split('=>'); { h1 => h2 } }.reduce(:merge)['query']
-      end
+      mail.text_part.decoded
     end
   end
 end


### PR DESCRIPTION
Closed #31

[対応内容]
・メールの本文からクエリを取得する

[確認内容]
・.rubocopファイルが修正されていること
　Semicolon許可の追加
・labor/mail_receiver.rbファイルが修正されていること

[動作確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

[メール確認・メール本文のquery内容確認]
_メール5通_
![image](https://user-images.githubusercontent.com/39178089/44451668-5e442c80-a62f-11e8-8006-f39adffa1851.png)

_上記、5通メールの1通目のメール本文内容_
![image](https://user-images.githubusercontent.com/39178089/44451795-ae22f380-a62f-11e8-8a7c-3087eb239a2e.png)

実行（rails console）・実行結果
![image](https://user-images.githubusercontent.com/39178089/44451556-0efdfc00-a62f-11e8-8b2a-1247451709a5.png)

修正後（commit 9a96cbf）の実行（rails console）・実行結果
![image](https://user-images.githubusercontent.com/39178089/44456977-eed53980-a63c-11e8-9c10-3d8cbd1ed777.png)
