### PR TITLE
DEV-38 未読メールのみを取得する

### DIFF
--- a/app/labor/mail_receiver.rb
+++ b/app/labor/mail_receiver.rb
@@ -15,8 +15,8 @@ module MailReceiver
     imap.login(ENV['GMAIL_USER_NAME'], ENV['GMAIL_PASSWORD'])
     # メールボックスを選択
     imap.select('INBOX')
-    # 全てのメールを取得
-    ids = imap.search(['ALL'])
+    # 未読(UNSEEN)のみ取得する
+    ids = imap.search(['UNSEEN'])
     imap.fetch(ids, 'RFC822').map do |m|
       mail = Mail.new(m.attr['RFC822'])
       email = mail.reply_to ? mail.reply_to[0] : mail.from[0]


### PR DESCRIPTION
Closed #38

[対応内容]
・未読メールのみを取得する

[確認内容]
・labor/mail_receiver.rbファイルが修正されていること

・未読みのメールが3通あること
![image](https://user-images.githubusercontent.com/39178089/44560728-14bd2400-a78c-11e8-9fb1-cdf19231e9d1.png)

[動作確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

lodqa_bs起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

実行
（rails runner lib/register_query.rb）
![image](https://user-images.githubusercontent.com/39178089/44560754-2f8f9880-a78c-11e8-8fa2-8b31cd371569.png)

未読みだったの3通メールが既読の状態になっていること
![image](https://user-images.githubusercontent.com/39178089/44560812-7aa9ab80-a78c-11e8-8527-27dd11c5504c.png)

実行結果（メール通知）
![image](https://user-images.githubusercontent.com/39178089/44560833-9319c600-a78c-11e8-8138-3da9bc2ff782.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-24T01:54:57.478+00:00", "finish_at"=>"2018-08-24T01:56:05.760+00:00", "elapsed_time"=>68.282815169, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1", "label"=>"ESR1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7", "label"=>"HSD3B7"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10", "label"=>"SOX10"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF", "label"=>"TNF"}], "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-24T01:54:57.478+00:00", "finish_at"=>"2018-08-24T01:56:05.760+00:00", "elapsed_time"=>68.282815169, "answers"=>[{"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1", "label"=>"ESR1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7", "label"=>"HSD3B7"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10", "label"=>"SOX10"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF", "label"=>"TNF"}]}}
```

```
{"event"=>"finish_search", "query"=>"first question", "start_at"=>"2018-08-24T01:55:03.188+00:00", "finish_at"=>"2018-08-24T01:55:05.797+00:00", "elapsed_time"=>2.609004451, "answers"=>[], "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@yahoo.com", "progress"=>{"event"=>"finish_search", "query"=>"first question", "start_at"=>"2018-08-24T01:55:03.188+00:00", "finish_at"=>"2018-08-24T01:55:05.797+00:00", "elapsed_time"=>2.609004451, "answers"=>[]}}
```

```
{"event"=>"start_search", "query"=>"first question", "start_at"=>"2018-08-24T01:55:03.188+00:00", "message"=>"Searching the query d4558181-f44a-400c-b905-85bb1e5e9485 have been starting.", "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@yahoo.com", "progress"=>{"event"=>"start_search", "query"=>"first question", "start_at"=>"2018-08-24T01:55:03.188+00:00", "message"=>"Searching the query d4558181-f44a-400c-b905-85bb1e5e9485 have been starting."}}
```

```
{"event"=>"finish_search", "query"=>"テストメールです", "start_at"=>"2018-08-24T01:54:57.462+00:00", "finish_at"=>"2018-08-24T01:55:00.527+00:00", "elapsed_time"=>3.065192896, "answers"=>[], "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"finish_search", "query"=>"テストメールです", "start_at"=>"2018-08-24T01:54:57.462+00:00", "finish_at"=>"2018-08-24T01:55:00.527+00:00", "elapsed_time"=>3.065192896, "answers"=>[]}}
```

```
{"event"=>"start_search", "query"=>"テストメールです", "start_at"=>"2018-08-24T01:54:57.462+00:00", "message"=>"Searching the query 26abf380-78e7-4310-815d-20cf4c899b5f have been starting.", "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"start_search", "query"=>"テストメールです", "start_at"=>"2018-08-24T01:54:57.462+00:00", "message"=>"Searching the query 26abf380-78e7-4310-815d-20cf4c899b5f have been starting."}}
```

```
{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-24T01:54:57.478+00:00", "message"=>"Searching the query 673bc9f8-8f1f-46cc-bada-b79a2823d235 have been starting.", "controller"=>"progresses", "action"=>"create", "query_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-24T01:54:57.478+00:00", "message"=>"Searching the query 673bc9f8-8f1f-46cc-bada-b79a2823d235 have been starting."}}
```