### PR TITLE
DEV-45 未読のメールが不在時のバグ対応

### DIFF
--- a/app/labor/mail_receiver.rb
+++ b/app/labor/mail_receiver.rb
@@ -17,15 +17,12 @@ module MailReceiver
     imap.select('INBOX')
     # 未読(UNSEEN)のみ取得する
     ids = imap.search(['UNSEEN'])
-    if ids.empty?
-      {}
-    else
-      imap.fetch(ids, 'RFC822').map do |m|
-        mail = Mail.new(m.attr['RFC822'])
-        email = mail.reply_to ? mail.reply_to[0] : mail.from[0]
-        body = mail.text_part.decoded
-        { email: email, body: body.chomp }
-      end
+    return [] if ids.empty?
+    imap.fetch(ids, 'RFC822').map do |m|
+      mail = Mail.new(m.attr['RFC822'])
+      email = mail.reply_to ? mail.reply_to[0] : mail.from[0]
+      body = mail.text_part.decoded
+      { email: email, body: body.chomp }
     end
   end
 end


### PR DESCRIPTION
Closed #45

[対応内容]
・未読のメールが不在時のバグ対応

[確認内容]
・labor/mail_receiver.rbファイルが修正されていること

[未読みのメールが不在確認]
![image](https://user-images.githubusercontent.com/39178089/44567249-958c1800-a7ac-11e8-87e4-6490e1369088.png)

### **バグ内容**
[動作確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

lodqa_bs起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

実行
（rails runner lib/register_query.rb）
空の配列をimapが対応できない
![image](https://user-images.githubusercontent.com/39178089/44567441-5ca07300-a7ad-11e8-93ef-0ee87e3105c4.png)

### **バグ対応**
[動作確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

lodqa_bs起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

実行（メール送信は行わない）
（rails runner lib/register_query.rb）
![image](https://user-images.githubusercontent.com/39178089/44567482-8ce81180-a7ad-11e8-9afe-49b95d9acf73.png)

