### PR TITLE
DEV-48 メールの送信先をコールバックURLをmails/mail-address/progressから取得する

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ HOST_LODQA_EMAIL_AGENT=host.docker.internal:80
 * 送信元のメールアドレス設定
 FROM_EMAIL=lodemailagent@gmail.com
 
-* 送信先のメールアドレス設定
-TO_EMAIL=[mail address]
-
 * 接続するメールサーバー(gmail)のメールアドレス設定
 * メールアカウントの2 段階認証プロセスを有効にする
 * （https://support.google.com/accounts/answer/185839?hl=ja&ref_topic=2954345）

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -3,9 +3,8 @@
 # コールバックを受け入れるパスを作る
 class ProgressesController < ApplicationController
   def create
-    to_email = mail_progress_path.split('/')[2]
     # メールを送信（SMTPサーバ使用）
-    EmailMailer.deliver_email('text mail', params, to_email)
+    EmailMailer.deliver_email('text mail', params)
   end
 
   def destroy

--- a/app/mailers/email_mailer.rb
+++ b/app/mailers/email_mailer.rb
@@ -4,12 +4,13 @@
 class EmailMailer < ActionMailer::Base
   default from: ENV['FROM_EMAIL']
 
-  def self.deliver_email(subject, body, to_email)
-    build_email(subject, body, to_email).deliver_now
+  def self.deliver_email(subject, body)
+    build_email(subject, body).deliver_now
   end
 
-  def build_email(subject, body, to_email)
+  def build_email(subject, body)
     @body = body
+    to_email = body[:mail_id]
     mail(to: to_email, subject: subject)
   end
 end


### PR DESCRIPTION
Closed #48

[対応内容]
・メールの送信先をコールバックURLをmails/mail-address/progressから取得する

[確認内容]
・controllers/progresses_controller.rbファイルが修正されていること
・mailers/email_mailer.rbファイルが修正されていること

[未読みのメール確認]
![image](https://user-images.githubusercontent.com/39178089/44698192-d9876180-aab9-11e8-8ac7-fddea090621c.png)
※個人メールのため名称非表示している

[動作確認]
lodqa_email_agent起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 80:3000 lodqa_email_agent bin/rails s -b 0.0.0.0

lodqa_bs起動
docker run -it --rm -v $(pwd):/usr/src/myapp -p 81:3000 lodqa_bs bin/rails s -b 0.0.0.0

実行
（bundle exec rails runner lib/register_query.rb）
![image](https://user-images.githubusercontent.com/39178089/44698252-210ded80-aaba-11e8-991e-c1e3695b099d.png)

**実行結果１（未読みだったの2通メールが既読の状態になっていること・メール通知）**
![image](https://user-images.githubusercontent.com/39178089/44698303-59adc700-aaba-11e8-9b68-3ab368dd2cfd.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-28T11:56:02.174+09:00", "finish_at"=>"2018-08-28T11:57:02.864+09:00", "elapsed_time"=>60.69057001, "answers"=>[{"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10", "label"=>"SOX10"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1", "label"=>"ESR1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF", "label"=>"TNF"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7", "label"=>"HSD3B7"}], "controller"=>"progresses", "action"=>"create", "mail_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"finish_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-28T11:56:02.174+09:00", "finish_at"=>"2018-08-28T11:57:02.864+09:00", "elapsed_time"=>60.69057001, "answers"=>[{"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA", "label"=>"EDNRA"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10", "label"=>"SOX10"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1", "label"=>"ESR1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB", "label"=>"EDNRB"}, {"uri"=>"http://bio2rdf.org/omim:131244", "label"=>"ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2", "label"=>"ATP1A2"}, {"uri"=>"http://bio2rdf.org/omim:131243", "label"=>"ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF", "label"=>"TNF"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1", "label"=>"ATP8B1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1", "label"=>"ECE1"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11", "label"=>"ABCB11"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4", "label"=>"ABCB4"}, {"uri"=>"http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7", "label"=>"HSD3B7"}]}}
```

```
{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-28T11:56:02.174+09:00", "message"=>"Searching the query 3a2cfc4d-7ea0-4d13-a64b-9a4436f9552e have been starting.", "controller"=>"progresses", "action"=>"create", "mail_id"=>"lodemailagent@gmail.com", "progress"=>{"event"=>"start_search", "query"=>"Which genes are associated with Endothelin receptor type B?", "start_at"=>"2018-08-28T11:56:02.174+09:00", "message"=>"Searching the query 3a2cfc4d-7ea0-4d13-a64b-9a4436f9552e have been starting."}}
```

**実行結果２（未読みだったの2通メールが既読の状態になっていること・メール通知・本文内容）**
![image](https://user-images.githubusercontent.com/39178089/44698303-59adc700-aaba-11e8-9b68-3ab368dd2cfd.png)


_個人メールへの通知_
![image](https://user-images.githubusercontent.com/39178089/44700151-b7461180-aac2-11e8-8af0-2408074cdff7.png)

![image](https://user-images.githubusercontent.com/39178089/44700155-bca35c00-aac2-11e8-8bf4-74db86092285.png)

