### PR TITLE
DEV-79 クエリーを登録する先のURLを変更する

### DIFF
--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -3,7 +3,7 @@
 # LODQA BSにHTTPリクエストを送る
 module LodqaClient
   class << self
-    SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/queries"
+    SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/searches"
 
     def post_query(question, address_to_send)
       start_callback_url = "http://#{ENV['HOST_LODQA_EMAIL_AGENT']}/mail/#{address_to_send}/start"


### PR DESCRIPTION
Closed #79

[対応内容]
・クエリーを登録する先のURLを変更する

[確認内容]
・labor/lodqa_client.rbファイルが修正していること
　queries→searchesに変更

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45132087-910f2880-b1ca-11e8-905e-76b7901488de.png)
※2通目は個人メールからのメールです。

[動作確認]
「docker-compose up」起動

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/register_query.rb）
![image](https://user-images.githubusercontent.com/39178089/45132098-9a989080-b1ca-11e8-8fd2-96dd1ec50478.png)

**実行結果１（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45132116-a5532580-b1ca-11e8-9e6c-28942e2071ff.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
No answer was found.
```

```
Searching the query have been starting.
```

**実行結果２（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45132151-c6b41180-b1ca-11e8-90bd-f62639be7549.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
[
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA",
    "label": "EDNRA"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10",
    "label": "SOX10"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1",
    "label": "ESR1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB",
    "label": "EDNRB"
  },
  {
    "uri": "http://bio2rdf.org/omim:131244",
    "label": "ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2",
    "label": "ATP1A2"
  },
  {
    "uri": "http://bio2rdf.org/omim:131243",
    "label": "ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF",
    "label": "TNF"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1",
    "label": "ATP8B1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1",
    "label": "ECE1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11",
    "label": "ABCB11"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4",
    "label": "ABCB4"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7",
    "label": "HSD3B7"
  }
]
```

```
Searching the query have been starting.
```
