### PR TITLE
DEV-85 sentメールを受信メールとしないようにする

### DIFF
--- a/app/labor/mail_receiver.rb
+++ b/app/labor/mail_receiver.rb
@@ -21,7 +21,7 @@ module MailReceiver
     mails = Mail.all
     return [] if mails.empty?
 
-    mails.map do |mail|
+    email_bodys = mails.map do |mail|
       next unless mail.text_part
       # 受信メール内容
       body = mail.text_part.decoded
@@ -29,5 +29,6 @@ module MailReceiver
       # メールアドレスと本文内容をハッシュ化
       { email: email, body: body.chomp }
     end
+    email_bodys.compact!
   end
 end

--- a/lib/check_new_mails.rb
+++ b/lib/check_new_mails.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 received_mails = MailReceiver.receive_mail
-received_mails.compact!
 received_mails.each do |mail|
   # LODQA BSにクエリーを登録するスクリプトを追加する
   LodqaClient.post_query mail[:body], mail[:email]


### PR DESCRIPTION
Closed #85

[対応内容]
・sentメールを受信メールとしないようにする

[確認内容]
・labor/mail_receiver.rbファイルが修正されていること
・lib/check_new_mails.rbファイルが修正されていること
　配列の引数（nil）を取り除く

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45207395-d151d200-b2c2-11e8-82e9-15317565d363.png)
※2通目は個人メールからのメールです。

[送信済メール確認]
![image](https://user-images.githubusercontent.com/39178089/45207429-e464a200-b2c2-11e8-99dc-d5fb19b56dd6.png)
※個人メールへの名前を消しています

[動作確認]
「docker-compose up」起動

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/45207488-0a8a4200-b2c3-11e8-998e-16bc7b6d69d1.png)

**実行結果１（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45207509-183fc780-b2c3-11e8-9a6f-210b00bde20e.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
No answer was found.
```

```
Searching the query have been starting.
```

**実行結果２（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45207559-3b6a7700-b2c3-11e8-87db-5f8a9edf752e.png)

実行結果（メール本文内容）
※以下、上記の画像メールの順で追加している
```
[
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA",
    "label": "EDNRA"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10",
    "label": "SOX10"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB",
    "label": "EDNRB"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1",
    "label": "ESR1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2",
    "label": "ATP1A2"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF",
    "label": "TNF"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1",
    "label": "ECE1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1",
    "label": "ATP8B1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4",
    "label": "ABCB4"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11",
    "label": "ABCB11"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7",
    "label": "HSD3B7"
  },
  {
    "uri": "http://bio2rdf.org/omim:131243",
    "label": "ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"
  },
  {
    "uri": "http://bio2rdf.org/omim:131244",
    "label": "ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"
  }
]
```

```
Searching the query have been starting.
```

**送信済メール確認（個人メールへ送信したメールがどちらとも2通、自分へ送信したメールが2通）**
![image](https://user-images.githubusercontent.com/39178089/45207623-65bc3480-b2c3-11e8-9f21-65e782c417ea.png)
※個人メールへの名前を消しています