### PR TITLE
DEV-84 LODQA_BSへのクエリ登録が失敗したときに失敗メールを送る

### DIFF
--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -11,8 +11,8 @@ module LodqaClient
                       callback_url: callback_url }
 
       RestClient::Request.execute method: :post, url: SERVER_URL, payload: post_params
-    rescue StandardError
-      FailureMailer.deliver_email('failure mail', 'Gateway error: LODQA BS server is unavailable.')
+    rescue Errno::ECONNREFUSED, Net::OpenTimeout, SocketError
+      FailureMailer.deliver_email('failure mail', address_to_send)
     end
   end
 end

--- a/app/mailers/failure_mailer.rb
+++ b/app/mailers/failure_mailer.rb
@@ -4,15 +4,11 @@
 class FailureMailer < ActionMailer::Base
   default from: ENV['FROM_EMAIL']
 
-  def self.deliver_email(subject, body)
-    # 送信先メールアドレスの取得
-    to_email = ENV['FROM_EMAIL']
-
-    build_email(subject, to_email, body).deliver_now
+  def self.deliver_email(subject, to_email)
+    build_email(subject, to_email).deliver_now
   end
 
-  def build_email(subject, to_email, body)
-    @body = body
+  def build_email(subject, to_email)
     mail(to: to_email, subject: subject, &:text)
   end
 end

--- a/app/views/failure_mailer/build_email.text.erb
+++ b/app/views/failure_mailer/build_email.text.erb
@@ -1,1 +1,1 @@
-<%= @body %>
+Gateway error: LODQA BS server is unavailable.


### PR DESCRIPTION
Closed #84

[対応内容]
・LODQA_BSへのクエリ登録が失敗したときに失敗メールを送る

[確認内容]
・labor/lodqa_client.rbファイルが修正されていること
・mailers/failure_mailer.rbファイルが追加されていること
・views/failure_mailer/build_email.text.erbが追加されていること

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45281170-ff792100-b511-11e8-9cd4-79019ebfa252.png)
※個人メールへの名前を消しています
**※1番目のメールの本文内容が「空」のメールでテストしています**

[動作確認]
「docker-compose up」起動

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/45281195-0869f280-b512-11e8-9386-483d8b563f01.png)

**実行結果１（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45281216-19b2ff00-b512-11e8-8b6b-eb8341490a32.png)

実行結果（メール本文内容が3番目の通知メール確認）
※以下、上記の画像メールの順で追加している
```
No answer was found.
```

```
Searching the query  "question?" have been starting.
```

```
Gateway error: LODQA BS server is unavailable.
```

**実行結果2（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45281441-c7bea900-b512-11e8-8cee-c5621a359fe1.png)

実行結果
※以下、上記の画像メールの順で追加している
```
[
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRA",
    "label": "EDNRA"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/SOX10",
    "label": "SOX10"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ESR1",
    "label": "ESR1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/EDNRB",
    "label": "EDNRB"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP1A2",
    "label": "ATP1A2"
  },
  {
    "uri": "http://bio2rdf.org/omim:131244",
    "label": "ENDOTHELIN RECEPTOR, TYPE B; EDNRB [omim:131244]"
  },
  {
    "uri": "http://bio2rdf.org/omim:131243",
    "label": "ENDOTHELIN RECEPTOR, TYPE A; EDNRA [omim:131243]"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/TNF",
    "label": "TNF"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ATP8B1",
    "label": "ATP8B1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ECE1",
    "label": "ECE1"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB11",
    "label": "ABCB11"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/ABCB4",
    "label": "ABCB4"
  },
  {
    "uri": "http://www4.wiwiss.fu-berlin.de/diseasome/resource/genes/HSD3B7",
    "label": "HSD3B7"
  }
]
```

```
Searching the query  "Which genes are associated with Endothelin receptor type B?" have been starting.
```

**### 修正（commit 249a6e4）**
テスト用のため、.envファイルの
HOST_LODQA_BS=lodqa_b:3000に変更してからテストしました。

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45284653-0c027700-b51c-11e8-9c9c-d5ece655bbad.png)

[スクリプト実行後の失敗メール確認１]
![image](https://user-images.githubusercontent.com/39178089/45284752-3a805200-b51c-11e8-80b1-b774027cdf7b.png)

```
Gateway error: LODQA BS server is unavailable.
```

[スクリプト実行後の失敗メール確認2]
![image](https://user-images.githubusercontent.com/39178089/45284784-55eb5d00-b51c-11e8-8b51-73df10dce04b.png)

```
Gateway error: LODQA BS server is unavailable.
```

