### PR TITLE
DEV-91 受信したメールの本文が空だった時は警告メールを送る

### DIFF
--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -6,14 +6,12 @@ module LodqaClient
     SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/searches"
 
     def post_query(question, address_to_send)
-      raise RestClient::ExceptionWithResponse if question.blank?
+      return WarningMailer.deliver_email('warning mail', address_to_send) if question.blank?
       callback_url = "http://#{ENV['HOST_LODQA_EMAIL_AGENT']}/mail/#{address_to_send}/events"
       post_params = { query: question,
                       callback_url: callback_url }
 
       RestClient::Request.execute method: :post, url: SERVER_URL, payload: post_params
-    rescue RestClient::ExceptionWithResponse
-      WarningMailer.deliver_email('warning mail', address_to_send)
     rescue Errno::ECONNREFUSED, Net::OpenTimeout, SocketError
       FailureMailer.deliver_email('failure mail', address_to_send)
     end

--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -11,6 +11,8 @@ module LodqaClient
                       callback_url: callback_url }
 
       RestClient::Request.execute method: :post, url: SERVER_URL, payload: post_params
+    rescue RestClient::ExceptionWithResponse
+      WarningMailer.deliver_email('warning mail', address_to_send)
     rescue Errno::ECONNREFUSED, Net::OpenTimeout, SocketError
       FailureMailer.deliver_email('failure mail', address_to_send)
     end

--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -6,6 +6,7 @@ module LodqaClient
     SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/searches"
 
     def post_query(question, address_to_send)
+      raise RestClient::ExceptionWithResponse if question.blank?
       callback_url = "http://#{ENV['HOST_LODQA_EMAIL_AGENT']}/mail/#{address_to_send}/events"
       post_params = { query: question,
                       callback_url: callback_url }

--- a/app/mailers/warning_mailer.rb
+++ b/app/mailers/warning_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# 失敗メール送信
+class WarningMailer < ActionMailer::Base
+  default from: ENV['FROM_EMAIL']
+
+  def self.deliver_email(subject, to_email)
+    build_email(subject, to_email).deliver_now
+  end
+
+  def build_email(subject, to_email)
+    mail(to: to_email, subject: subject, &:text)
+  end
+end

--- a/app/views/warning_mailer/build_email.text.erb
+++ b/app/views/warning_mailer/build_email.text.erb
@@ -1,0 +1,1 @@
+The body of the mail was empty and cannot be processed.


### PR DESCRIPTION
Closed #91 

[対応内容]
・受信したメールの本文が空だった時は警告メールを送る

[確認内容]
・labor/lodqa_client.rbファイルが修正されていること
　例外処理追加
・mailers/warning_mailer.rbファイルが追加されていること
・views/warning_mailer/build_email.text.erbが追加されていること

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45334626-8e3f7980-b5b6-11e8-9dcd-b9b1cb19f33e.png)
※個人メールへの名前を消しています
※1、3番目のメールの本文内容が「空」のメールです

[動作確認]
「docker-compose up」起動

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/45334743-102fa280-b5b7-11e8-9753-1458356be61b.png)

**実行結果１（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45334753-1887dd80-b5b7-11e8-9523-28a7a65d3329.png)

実行結果（メール本文内容が1-3番までの通知メール確認）
※以下、上記の画像メールの順で追加している
```
No answer was found.
```

```
Searching the query  "質問？" have been starting.
```

```
The body of the mail was empty and cannot be processed.
```

**実行結果2（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45334818-6ac8fe80-b5b7-11e8-8466-d25e5efb7185.png)

実行結果
※以下、上記の画像メールの順で追加している
```
The body of the mail was empty and cannot be processed.
```
