### PR TITLE
DEV-94 メールのタイトルをクエリに変える

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,20 +10,22 @@ class EventsController < ApplicationController
     to_email = params[:mail_id]
     # 検索IDの取得
     search_id = params[:search_id]
+    # クエリーの取得
+    subject = params[:query][0, 130]
     # イベントで判別し、開始・終了のメール送信を行う
     case event
     when 'start' then
       # クエリーの取得
       query = params[:query]
       # 開始メールを送信（SMTPサーバ使用）
-      StartMailer.deliver_email('start mail', to_email, query, search_id)
+      StartMailer.deliver_email(subject, to_email, query, search_id)
     when 'finish' then
       # メール本文の取得
       answers = params[:answers]
       # 回答の項目数取得
       items_count = answers.blank? ? 0 : answers.length
       # 終了メールを送信（SMTPサーバ使用）
-      FinishMailer.deliver_email('finish mail', to_email, items_count, search_id)
+      FinishMailer.deliver_email(subject, to_email, items_count, search_id)
     else
       logger.info('イベント「'"#{event}"'」は想定していないイベントです。')
     end


### PR DESCRIPTION
Closed #94

[対応内容]
・メールのタイトルをクエリに変える

[確認内容]
・controllers/events_controller.rbファイルが修正されていること
　取得したクエリが130文字以上のときは、130文字までに制限しています

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/45351430-20fd0a00-b5f1-11e8-9d3c-2082248217d6.png)
※個人メールへの名前を消しています

自分へのメール(タイトル：news)本文内容
```
If you are wondering why he was proud, you’re not alone. He depicts Serena Williams, one of the greatest athletes of all time, as a racist stereotype, with a huge nose and big lips. She is drawn like a Hulk baby, her strength and power twisted into infantile ugliness as she stomps on her racquet with a pacifier on the ground.
```

[動作確認]
「docker-compose up」起動

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/45351447-2eb28f80-b5f1-11e8-8a9f-be7a42080773.png)

**実行結果１（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45351560-70dbd100-b5f1-11e8-99aa-4d4f2d4befb3.png)

実行結果（タイトル確認）
※以下、上記の画像メールの順で追加している
```
If you are wondering why he was proud, you’re not alone. He depicts Serena Williams, one of the greatest athletes of all time, as
```

```
If you are wondering why he was proud, you’re not alone. He depicts Serena Williams, one of the greatest athletes of all time, as
```

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
```
No answer was found.
```

```
I am beginning to find the answer to the following question:
"If you are wondering why he was proud, you’re not alone. He depicts Serena
Williams, one of the greatest athletes of all time, as a racist stereotype,
with a huge nose and big lips. She is drawn like a Hulk baby, her strength
and power twisted into infantile ugliness as she stomps on her racquet with
a pacifier on the ground."

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=3b334f9b-222d-4031-8f68-8279675a7e4c
```

**実行結果2（メール通知）**
![image](https://user-images.githubusercontent.com/39178089/45351697-bd271100-b5f1-11e8-84bf-c06e0d0f8066.png)


実行結果（タイトル確認）
※以下、上記の画像メールの順で追加している
```
Which genes are associated with Endothelin receptor type B?
```

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
```
I am beginning to find the answer to the following question:
"Which genes are associated with Endothelin receptor type B?"

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=3eb3959a-c722-4b8d-9c2b-6c875aa5faf9
```

```
13 items have been found as the answer to your question.
You can see the results at:
http://lodqa.org/answer?search_id=3eb3959a-c722-4b8d-9c2b-6c875aa5faf9
```