### PR TITLE
DEV-128 環境変数でPOP_USESSL=falseにしてもSSLとして接続しようとする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module Myapp
       user_name: ENV['POP_USERNAME'],
       password: ENV['POP_PASSWORD'],
       # 暗号化あり:true、暗号化なし:falseを指定する必要がある。
-      use_ssl: ENV['POP_USESSL'] != 'true'
+      use_ssl: ENV['POP_USESSL'] == 'true'
     }
   end
 end


### PR DESCRIPTION
Closed #128

[対応内容]
・環境変数でPOP_USESSL=falseにしてもSSLとして接続しようとする

[確認内容]
・config/application.rbファイルが修正されていること
　pop_settingsのENV['POP_USESSL'] != 'true'をENV['POP_USESSL'] == 'true'に変更

・環境変数でPOP_USESSL=falseにして確認済

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46120268-de226f80-c249-11e8-9bb3-106fbae88c89.png)

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/46120275-e7134100-c249-11e8-9296-eeca0f9796f8.png)

実行結果（メール削除・メール通知（２通））
![image](https://user-images.githubusercontent.com/39178089/46120291-f09ca900-c249-11e8-9d8c-4d47f3dd230c.png)

_lodemailagent@gmail.comへの送信_

![image](https://user-images.githubusercontent.com/39178089/46120299-fbefd480-c249-11e8-8c53-d82e687e7c0e.png)

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
```
I am beginning to find the answer to the following question:
"Which genes are associated with Endothelin receptor type B?"

with options below:
read_timeout=5
sparql_limit=99
answer_limit=10
cache=yes

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=1d025fdb-8b2d-4206-a6cc-38593d13ada1
```

```
13 items have been found as the answer to your question.
You can see the results at:
http://lodqa.org/answer?search_id=1d025fdb-8b2d-4206-a6cc-38593d13ada1
```
