### PR TITLE
DEV-132 受信メールのオプションにtargetを増やす

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -40,6 +40,7 @@ class EventsController < ApplicationController
     options[:sparql_limit] = params[:sparql_limit]
     options[:answer_limit] = params[:answer_limit]
     options[:cache] = params[:cache]
+    options[:target] = params[:target]
     options
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -40,7 +40,7 @@ class EventsController < ApplicationController
     options[:sparql_limit] = params[:sparql_limit]
     options[:answer_limit] = params[:answer_limit]
     options[:cache] = params[:cache]
-    options[:target] = params[:target]
+    options[:target] = params[:target] if params[:target].present?
     options
   end
 end

--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -25,7 +25,7 @@ module LodqaClient
       post_params[:sparql_limit] = option['sparql_limit'] if option['sparql_limit'].present?
       post_params[:answer_limit] = option['answer_limit'] if option['answer_limit'].present?
       post_params[:cache] = option['cache'] if option['cache'].present?
-      post_params[:cache] = option['target'] if option['target'].present?
+      post_params[:target] = option['target'] if option['target'].present?
       post_params
     end
   end

--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -25,6 +25,7 @@ module LodqaClient
       post_params[:sparql_limit] = option['sparql_limit'] if option['sparql_limit'].present?
       post_params[:answer_limit] = option['answer_limit'] if option['answer_limit'].present?
       post_params[:cache] = option['cache'] if option['cache'].present?
+      post_params[:cache] = option['target'] if option['target'].present?
       post_params
     end
   end

--- a/spec/labor/lod_client_spec.rb
+++ b/spec/labor/lod_client_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe LodqaClient do
     end
 
     context 'LODQA_BSから成功レスポンスが帰ってきたとき' do
-      let(:option) { { 'read_timeout' => 10, 'sparql_limit' => 100, 'answer_limit' => 10, 'cache' => 'no' } }
+      let(:option) { { 'read_timeout' => 10, 'sparql_limit' => 100, 'answer_limit' => 10, 'cache' => 'no', 'target' => 'bio2rdf-mashup' } }
       before do
         registered_query = { callback_url: "http://lodqa_email_agent:3000/mail/#{address_to_send}/events",
-                             answer_limit: 10, cache: 'no', query: question, read_timeout: 10, sparql_limit: 100 }
+                             answer_limit: 10, cache: 'no', query: question, read_timeout: 10, sparql_limit: 100, target: 'bio2rdf-mashup' }
         @stub_success = stub_request(:post, LodqaClient::SERVER_URL).with(body: registered_query).to_return(status: 200)
       end
       it 'nilを返すこと' do


### PR DESCRIPTION
Closed #132

[対応内容]
・受信メールのオプションにtargetを増やす

[確認内容]
・controllers/events_controller.rbファイルが修正されていること
　LODQA_BS側からのeventパラメータ情報にtargetが追加される前提で
　options[:target]に指定している
・labor/lodqa_client.rbファイルが修正されていること
　受信した本文のtargetをLODQA_BSに登録

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46526043-23891180-c8c8-11e8-86c0-09e547827aee.png)

![image](https://user-images.githubusercontent.com/39178089/46526049-25eb6b80-c8c8-11e8-820d-6843be53dc95.png)

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/46526063-2e43a680-c8c8-11e8-9b30-ec31a4625762.png)

実行結果（メール削除・メール通知（4通））
![image](https://user-images.githubusercontent.com/39178089/46526071-36034b00-c8c8-11e8-9160-742a74ec03e3.png)

![image](https://user-images.githubusercontent.com/39178089/46526073-3865a500-c8c8-11e8-9971-02574fbb49b7.png)

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
※LODQA_BS側からのeventにtarget追加される前提
```
I am beginning to find the answer to the following question:
"Which genes are associated with Endothelin receptor type B?"

with options below:
read_timeout=5
sparql_limit=100
answer_limit=10
cache=yes
target=

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=6e25db0f-1226-4012-a1a0-d4b2ef48487a
```

```
11 items have been found as the answer to your question.
You can see the results at:
http://lodqa.org/answer?search_id=6e25db0f-1226-4012-a1a0-d4b2ef48487a
```

```
I am beginning to find the answer to the following question:
"Which genes are involved in calcium binding?"

with options below:
read_timeout=5
sparql_limit=100
answer_limit=10
cache=yes
target=

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=1414a369-d16a-4498-b869-6bf66dba72ad
```

```
No answer was found.
```

commit 837cae5

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46527426-2423a700-c8cc-11e8-9015-55c61ad24cd1.png)

実行後のstartメール本文確認
LODQA_BS側からのeventにtarget情報がないため、targetをstartメール本文に出力されない
```
I am beginning to find the answer to the following question:
"Which genes are involved in calcium binding?"

with options below:
read_timeout=5
sparql_limit=100
answer_limit=10
cache=yes

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=b407a106-676a-4f38-ab30-24811eab67d4
```