### PR TITLE
DEV-139 app/labor/lodqa_client.rbのインタフェースを修正

### DIFF
--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -12,9 +12,11 @@ module LodqaClient
 
       RestClient::Request.execute method: :post, url: SERVER_URL, payload: post_params
       puts 'POST succcess.'
+      true
     rescue Errno::ECONNREFUSED, Net::OpenTimeout, SocketError
       FailureMailer.deliver_email('failure mail', address_to_send)
       puts 'POST failed.'
+      false
     end
 
     private

--- a/spec/labor/lod_client_spec.rb
+++ b/spec/labor/lod_client_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LodqaClient do
         @stub_success = stub_request(:post, LodqaClient::SERVER_URL).with(body: registered_query).to_return(status: 200)
       end
       it 'nilを返すこと' do
-        expect(subject.post_query(question, address_to_send, option)).to eq nil
+        expect(subject.post_query(question, address_to_send, option)).to eq true
       end
       it 'LODQA_BSを呼び出すこと' do
         subject.post_query(question, address_to_send, option)
@@ -31,7 +31,7 @@ RSpec.describe LodqaClient do
     context '異常レスポンスが帰ってきた時' do
       before { stub_request(:post, LodqaClient::SERVER_URL).to_raise Errno::ECONNREFUSED }
       it 'nilを返すこと' do
-        expect(subject.post_query(question, address_to_send, {})).to eq nil
+        expect(subject.post_query(question, address_to_send, {})).to eq false
       end
       it 'エラーメールが送信されることを確認' do
         allow(FailureMailer).to receive(:deliver_email)


### PR DESCRIPTION
Closed #139

[対応内容]
・app/labor/lodqa_client.rbのインタフェースを修正

[確認内容]
・app/labor/lodqa_client.rbファイルが修正されていること
　正常終了時はtrue、異常終了時はfalseを返す
・spec/labor/lod_client_spec.rbファイルが修正されていること
　上記修正により、比較処理の修正

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46647008-88927f00-cbc8-11e8-8030-5b7c50f1a36c.png)

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/46647012-90eaba00-cbc8-11e8-9320-1f024715ca16.png)

実行結果（メール削除・メール通知（2通））
![image](https://user-images.githubusercontent.com/39178089/46647019-9c3de580-cbc8-11e8-9255-38971b062b05.png)

_lodemailagent@gmail.comへの送信_
![image](https://user-images.githubusercontent.com/39178089/46647031-a5c74d80-cbc8-11e8-8985-bce46d088330.png)

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
```
I am beginning to find the answer to the following question:
"Which genes are associated with Endothelin receptor type B?"

with options below:
read_timeout=9
sparql_limit=99
answer_limit=9
cache=yes

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=f1489d0e-b17e-42e3-bb0e-2d5d7a0c1676
```

```
13 items have been found as the answer to your question.
You can see the results at:
http://lodqa.org/answer?search_id=f1489d0e-b17e-42e3-bb0e-2d5d7a0c1676
```

**RSpecの結果**
![image](https://user-images.githubusercontent.com/39178089/46647055-d313fb80-cbc8-11e8-81b5-07e1136caf50.png)


