### PR TITLE
DEV-143 RSpec実行時にSERVER_URL定数を再設定した警告が表示される

### DIFF
--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -2,7 +2,6 @@
 
 # LODQA BSにHTTPリクエストを送る
 module LodqaClient
-  SERVER_URL = "http://#{ENV['HOST_LODQA_BS']}/searches"
   class << self
     def post_query(question, address_to_send, option)
       return WarningMailer.deliver_email('warning mail', address_to_send) if question.blank?
@@ -10,7 +9,8 @@ module LodqaClient
       post_params = { query: question, callback_url: callback_url }
       post_params = populate_options(post_params, option) if option.present?
 
-      RestClient::Request.execute method: :post, url: SERVER_URL, payload: post_params
+      server_url = "http://#{ENV['HOST_LODQA_BS']}/searches"
+      RestClient::Request.execute method: :post, url: server_url, payload: post_params
       puts 'POST succcess.'
       true
     rescue Errno::ECONNREFUSED, Net::OpenTimeout, SocketError

--- a/spec/labor/lod_client_spec.rb
+++ b/spec/labor/lod_client_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe LodqaClient do
   describe 'post_query' do
     let(:question) { 'answers?' }
     let(:address_to_send) { 'lodemailagent@gmail.com' }
+    let(:server_url) { 'http://lodqa_bs:3000/searches' }
     before(:all) do
       ENV['HOST_LODQA_EMAIL_AGENT'] = 'lodqa_email_agent:3000'
       ENV['FROM_EMAIL'] = 'lodqa_test@luxiar.com'
-      LodqaClient::SERVER_URL = 'http://lodqa_bs:3000/searches'
+      ENV['HOST_LODQA_BS'] = 'lodqa_bs:3000'
     end
 
     context 'LODQA_BSから成功レスポンスが帰ってきたとき' do
@@ -17,7 +18,7 @@ RSpec.describe LodqaClient do
       before do
         registered_query = { callback_url: "http://lodqa_email_agent:3000/mail/#{address_to_send}/events",
                              answer_limit: 10, cache: 'no', query: question, read_timeout: 10, sparql_limit: 100, target: 'bio2rdf-mashup' }
-        @stub_success = stub_request(:post, LodqaClient::SERVER_URL).with(body: registered_query).to_return(status: 200)
+        @stub_success = stub_request(:post, server_url).with(body: registered_query).to_return(status: 200)
       end
       it 'trueを返すこと' do
         expect(subject.post_query(question, address_to_send, option)).to eq true
@@ -29,7 +30,7 @@ RSpec.describe LodqaClient do
     end
 
     context '異常レスポンスが帰ってきた時' do
-      before { stub_request(:post, LodqaClient::SERVER_URL).to_raise Errno::ECONNREFUSED }
+      before { stub_request(:post, server_url).to_raise Errno::ECONNREFUSED }
       it 'falseを返すこと' do
         expect(subject.post_query(question, address_to_send, {})).to eq false
       end


### PR DESCRIPTION
Closed #143

[対応内容]
・RSpec実行時にSERVER_URL定数を再設定した警告が表示される

[確認内容]
・app/labor/lodqa_client.rbファイルが修正されていること
　SERVER_URL定数を使わずに、環境変数から直接URLを生成する
・spec/labor/lod_client_spec.rbファイルが修正されていること
　上記修正により、変更修正

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46648972-3d7d6980-cbd2-11e8-9fe7-474de816b351.png)

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/46648978-440be100-cbd2-11e8-8b3d-183207314f8c.png)

実行結果（メール削除・メール通知（2通））
![image](https://user-images.githubusercontent.com/39178089/46648987-4a9a5880-cbd2-11e8-8284-28dcfc83ee6c.png)

_lodemailagent@gmail.comへの送信_
![image](https://user-images.githubusercontent.com/39178089/46648996-5259fd00-cbd2-11e8-9134-defff5cb61f3.png)

実行結果（メール本文内容確認）
※以下、上記の画像メールの順で追加している
```
I am beginning to find the answer to the following question:
"Which genes are associated with Endothelin receptor type B?"

with options below:
read_timeout=9
sparql_limit=99
answer_limit=9
cache=yes

I will send you the answer when the search is completed.

If you want, you can check the progress at any time:
http://lodqa.org/answer?search_id=f1489d0e-b17e-42e3-bb0e-2d5d7a0c1676
```

```
13 items have been found as the answer to your question.
You can see the results at:
http://lodqa.org/answer?search_id=f1489d0e-b17e-42e3-bb0e-2d5d7a0c1676
```

**RSpecの結果**

![image](https://user-images.githubusercontent.com/39178089/46649024-70bff880-cbd2-11e8-99b4-ef950458f8a7.png)



