### PR TITLE
DEV-134 通知メールのタイトルを受信メールのタイトルの前に Re: を追加したものにする

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,10 +6,10 @@ class EventsController < ApplicationController
     # イベントの取得
     event = params[:event]
     return render status: 400 if event.blank?
-    # 送信先メールアドレス・検索ID・クエリーの取得
-    to_email = params[:mail_id]
+    # 送信先メールアドレス・検索ID・件名の取得
+    to_email = params[:mail_address_id]
     search_id = params[:search_id]
-    subject = params[:query][0, 130]
+    subject = "Re: #{URI.decode_www_form_component(params[:mail_subject_id])[0, 130]}"
     # イベントで判別し、開始・終了のメール送信を行う
     case event
     when 'start' then

--- a/app/labor/lodqa_client.rb
+++ b/app/labor/lodqa_client.rb
@@ -3,9 +3,10 @@
 # LODQA BSにHTTPリクエストを送る
 module LodqaClient
   class << self
-    def post_query(question, address_to_send, option)
+    def post_query(question, address_to_send, subject, option)
       return WarningMailer.deliver_email('warning mail', address_to_send) if question.blank?
-      callback_url = "http://#{ENV['HOST_LODQA_EMAIL_AGENT']}/mail/#{address_to_send}/events"
+      mail_subject = URI.encode_www_form_component(subject)
+      callback_url = "http://#{ENV['HOST_LODQA_EMAIL_AGENT']}/mail_address/#{address_to_send}/mail_subject/#{mail_subject}/events"
       post_params = { query: question, callback_url: callback_url }
       post_params = populate_options(post_params, option) if option.present?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@
 Rails.application.routes.draw do
   # http://www.nslabs.jp/email-address-regular-expression.rhtml
   VALID_EMAIL_REGEX = /[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/
-  resources :mail, constraints: { id: VALID_EMAIL_REGEX } , only: [] do
-    resource :events, only: :create
+  resources :mail_address, constraints: { id: VALID_EMAIL_REGEX } , only: [] do
+    resources :mail_subject, constraints: { id: :none }, only: [] do
+      resource :events, only: :create
+    end
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/lib/check_new_mails.rb
+++ b/lib/check_new_mails.rb
@@ -6,5 +6,5 @@ received_mails = MailReceiver.receive_mail
 received_mails.each do |mail|
   # LODQA BSにクエリーを登録するスクリプトを追加する
   puts "POST query #{mail[:query]} to the LODQA_BS."
-  LodqaClient.post_query mail[:query], mail[:reply_to], mail[:query_option]
+  LodqaClient.post_query mail[:query], mail[:reply_to], mail[:subject], mail[:query_option]
 end

--- a/lib/mail_receiver.rb
+++ b/lib/mail_receiver.rb
@@ -37,10 +37,11 @@ module MailReceiver
     def to_hash(mail)
       # 受信メール内容
       email = mail.reply_to ? mail.reply_to[0] : mail.from[0]
+      subject = mail.subject
       query_option = body_option(mail.text_part.decoded)
       query = query_option['query']
       # メールアドレスとタイトルとクエリーオプションをハッシュ化
-      { reply_to: email, query: query, query_option: query_option }
+      { reply_to: email, subject: subject, query: query, query_option: query_option }
     end
 
     # 本文情報でクエリのオプション値として設定

--- a/spec/labor/lod_client_spec.rb
+++ b/spec/labor/lod_client_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe LodqaClient do
   describe 'post_query' do
     let(:question) { 'answers?' }
+    let(:mail_subject) { 'please' }
     let(:address_to_send) { 'lodemailagent@gmail.com' }
     let(:server_url) { 'http://lodqa_bs:3000/searches' }
     before(:all) do
@@ -16,15 +17,15 @@ RSpec.describe LodqaClient do
     context 'LODQA_BSから成功レスポンスが帰ってきたとき' do
       let(:option) { { 'read_timeout' => 10, 'sparql_limit' => 100, 'answer_limit' => 10, 'cache' => 'no', 'target' => 'bio2rdf-mashup' } }
       before do
-        registered_query = { callback_url: "http://lodqa_email_agent:3000/mail/#{address_to_send}/events",
+        registered_query = { callback_url: "http://lodqa_email_agent:3000/mail_address/#{address_to_send}/mail_subject/#{mail_subject}/events",
                              answer_limit: 10, cache: 'no', query: question, read_timeout: 10, sparql_limit: 100, target: 'bio2rdf-mashup' }
         @stub_success = stub_request(:post, server_url).with(body: registered_query).to_return(status: 200)
       end
       it 'trueを返すこと' do
-        expect(subject.post_query(question, address_to_send, option)).to eq true
+        expect(subject.post_query(question, address_to_send, mail_subject, option)).to eq true
       end
       it 'LODQA_BSを呼び出すこと' do
-        subject.post_query(question, address_to_send, option)
+        subject.post_query(question, address_to_send, mail_subject, option)
         expect(@stub_success).to have_been_requested
       end
     end
@@ -32,7 +33,7 @@ RSpec.describe LodqaClient do
     context '異常レスポンスが帰ってきた時' do
       before { stub_request(:post, server_url).to_raise Errno::ECONNREFUSED }
       it 'falseを返すこと' do
-        expect(subject.post_query(question, address_to_send, {})).to eq false
+        expect(subject.post_query(question, address_to_send, mail_subject, {})).to eq false
       end
       it 'エラーメールが送信されることを確認' do
         allow(FailureMailer).to receive(:deliver_email)

--- a/spec/labor/lod_client_spec.rb
+++ b/spec/labor/lod_client_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe LodqaClient do
   describe 'post_query' do
     let(:question) { 'answers?' }
-    let(:mail_subject) { 'please' }
     let(:address_to_send) { 'lodemailagent@gmail.com' }
+    let(:mail_subject) { 'please' }
     let(:server_url) { 'http://lodqa_bs:3000/searches' }
     before(:all) do
       ENV['HOST_LODQA_EMAIL_AGENT'] = 'lodqa_email_agent:3000'


### PR DESCRIPTION
Closed #134

[対応内容]
・通知メールのタイトルを受信メールのタイトルの前に Re: を追加したものにする

[確認内容]
・config/routes.rbファイルが修正されていること
・lib/mail_receiver.rbファイルが修正されていること
　件名の取得追加
・lib/check_new_mails.rbファイルが修正されていること
　件名をパラメータとして追加
・app/controllers/events_controller.rbファイルが修正されていること
　送信先メールアドレス・件名の取得変更
・app/labor/lodqa_client.rbファイルが修正されていること
　post_queryにパラメータ（subject）追加、エンコードしてコールバックURLに含む
・spec/labor/lod_client_spec.rbファイルが修正されていること
　上記修正により、変更反映

[受信するメール確認]
![image](https://user-images.githubusercontent.com/39178089/46716167-e80e8e80-cc9d-11e8-868c-7f3dcbaea8ce.png)

![image](https://user-images.githubusercontent.com/39178089/46716170-eb097f00-cc9d-11e8-93c4-23cee0347234.png)
タイトル
```
Endothelin receptor type BWhich genes are associated with Endothelin receptor type BWhich genes are associated with Endothelin receptor type B
```
※件名が130桁で切り取られる

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
![image](https://user-images.githubusercontent.com/39178089/46716221-18eec380-cc9e-11e8-8569-924bdcbb4622.png)


実行結果（メール削除・メール通知（4通））
![image](https://user-images.githubusercontent.com/39178089/46716232-27d57600-cc9e-11e8-81c0-d6a1fe743a22.png)

実行結果（メール本文内容確認）
![image](https://user-images.githubusercontent.com/39178089/46716348-99adbf80-cc9e-11e8-821f-1bdc5437523a.png)

![image](https://user-images.githubusercontent.com/39178089/46716583-9109b900-cc9f-11e8-9386-34482291282d.png)


![image](https://user-images.githubusercontent.com/39178089/46716584-936c1300-cc9f-11e8-9141-371c61ad87cd.png)

