### PR TITLE
issue #148 送信メールの本文のquery内容を変数に指定せずに、一行目をquery内容とする

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HTML形式で記載してください。
 内容はINI形式で記述します。
 例えば、次のように記述します。
 
-    query=Which genes are associated with Endothelin receptor type B?
+    Which genes are associated with Endothelin receptor type B?
     read_timeout=5
     sparql_limit=100
     answer_limit=10
@@ -30,7 +30,7 @@ HTML形式で記載してください。
 
 | パラメーター名      | 意味                             | 必須    |
 | :----------- | :----------------------------- | :---- |
-| query        | 質問文                            | true  |
+|              | 質問文                            | true  |
 | read_timeout | SPARQLクエリのタイムアウト時間             | false |
 | sparql_limit | 一つのanhored pgpから生成するSPARQL数の上限 | false |
 | answer_limit | 一つのSPAQRQLから取得するsolutionの上限    | false |

--- a/lib/mail_receiver.rb
+++ b/lib/mail_receiver.rb
@@ -46,6 +46,7 @@ module MailReceiver
 
     # 本文情報でクエリのオプション値として設定
     def body_option(body)
+      body.gsub!(body.lines[0], "query=#{body.lines[0]}")
       option = IniFile.new(content: body)
       option[:global]
     rescue IniFile::Error

--- a/lib/mail_receiver.rb
+++ b/lib/mail_receiver.rb
@@ -46,6 +46,8 @@ module MailReceiver
 
     # 本文情報でクエリのオプション値として設定
     def body_option(body)
+      # メール本文の一行目はquery内容とする。
+      # iniファイル化するには、取得したquery内容をquery変数に指定する。
       body.gsub!(body.lines[0], "query=#{body.lines[0]}")
       option = IniFile.new(content: body)
       option[:global]


### PR DESCRIPTION
closed #148 

[対応内容]
・送信メールの本文のquery内容を変数に指定しない
・本文内容の一行目をquery内容と判定して処理する

[確認内容]
・lib/mail_receiver.rbファイルが修正されていること

[受信するメール確認]
<img width="531" alt="スクリーンショット 2020-03-16 13 16 44" src="https://user-images.githubusercontent.com/39178089/76722803-7d159100-6788-11ea-9e24-0dbe8b15e86e.png">

実行
（docker-compose run --rm lodqa_email_agent sh）
　（bundle exec rails runner lib/check_new_mails.rb）
<img width="649" alt="スクリーンショット 2020-03-16 13 18 48" src="https://user-images.githubusercontent.com/39178089/76722863-b948f180-6788-11ea-9985-ecc98cb60d8f.png">

実行結果（メール通知）

<img width="1021" alt="スクリーンショット 2020-03-16 13 21 56" src="https://user-images.githubusercontent.com/39178089/76723059-586de900-6789-11ea-8c6e-eb38d6b1c92f.png">
<img width="986" alt="スクリーンショット 2020-03-16 13 22 09" src="https://user-images.githubusercontent.com/39178089/76723062-5a37ac80-6789-11ea-8ad5-9bcfe7d8922e.png">


